### PR TITLE
changed path in README.md for computer diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ git commit -m 'adding readme and test'
 
 git remote -v
 
-git remote add origin https://github.com/Jason-Doze/pantera.git
+git remote add origin /Users/jasondoze13/pantera/computerDiagram.png
 
 git remote -v
 


### PR DESCRIPTION
looks like the repo still doesnt contain the correct pathway for the diagram but the diagram is in the repo. 